### PR TITLE
修复：把 Maven 发布中修改为 AAR 打包

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -88,6 +88,10 @@ afterEvaluate {
                 version = defVersionName
 
                 artifact androidSourcesJar
+
+                pom {
+                    packaging = "aar"
+                }
             }
         }
     }


### PR DESCRIPTION
- 将 `packaging = "aar"` 添加到 `api/build.gradle` 文件中 `maven-publish` 插件的 pom 配置中。