### PR TITLE
fix: include hidden-api classes in published AAR artifact

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -78,7 +78,7 @@ tasks.register('androidSourcesJar', Jar) {
 }
 
 dependencies {
-    compileOnly project(':hidden-api')
+    implementation project(':hidden-api')
     implementation libs.annotation
 }
 


### PR DESCRIPTION
Change `compileOnly project(':hidden-api')` to `implementation project(':hidden-api')` so that hidden-api classes are included in the published AAR artifact.